### PR TITLE
Feat/create travel order

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Here I'm using the fpm base image to build a PHP application.
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 # Install necessary tools for using Composer
 
 ARG user

--- a/backend/app/DTO/TravelOrderDTO.php
+++ b/backend/app/DTO/TravelOrderDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\DTO;
+
+use Illuminate\Support\Carbon;
+
+readonly class TravelOrderDTO
+{
+  public function __construct(
+    public string $requester_name,
+    public string $destination,
+    public Carbon $departure_date,
+    public Carbon $return_date
+  ) {}
+  /**
+   * Creates the TravelOrderDTO from an array.
+   *
+   * @param array $data
+   * @return self
+   */
+  public static function fromArray(array $data): self
+  {
+    return new self(
+      requester_name: $data['requester_name'],
+      destination: $data['destination'],
+      departure_date: Carbon::parse($data['departure_date']),
+      return_date: Carbon::parse($data['return_date'])
+    );
+  }
+}

--- a/backend/app/Enum/TravelOrderStatus.php
+++ b/backend/app/Enum/TravelOrderStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum TravelOrderStatus: string
+{
+  case Cancelled = 'cancelled';
+  case Approved = 'approved';
+  case Pending = 'pending';
+}

--- a/backend/app/Http/Controllers/TravelOrderController.php
+++ b/backend/app/Http/Controllers/TravelOrderController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\DTO\TravelOrderDTO;
+use App\Http\Requests\StoreTravelOrderRequest;
+use App\Models\TravelOrder;
+use App\Services\TravelOrderService;
+use Illuminate\Http\Request;
+
+class TravelOrderController extends Controller
+{
+    public function __construct(private TravelOrderService $service)
+    {
+        //
+    }
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreTravelOrderRequest $request)
+    {
+
+        $orderDTO = TravelOrderDTO::fromArray($request->validated());
+        $user = auth()->user();
+        return $this->service->createOrder($user, $orderDTO);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(TravelOrder $travelOrder)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, TravelOrder $travelOrder)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(TravelOrder $travelOrder)
+    {
+        //
+    }
+}

--- a/backend/app/Http/Requests/StoreTravelOrderRequest.php
+++ b/backend/app/Http/Requests/StoreTravelOrderRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTravelOrderRequest extends FormRequest
+{
+    protected $stopOnFirstFailure = true;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // I will use gates and policies here
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'requester_name' => 'required|string|max:255',
+            'destination' => 'required|string|max:255',
+            'departure_date' => 'required|date_format:Y-m-d|after:today',
+            'return_date' => 'required|date_format:Y-m-d|after:departure_date'
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'requester_name.required'   => 'O nome do solicitante é obrigatório.',
+            'requester_name.string'     => 'O nome do solicitante deve ser um texto.',
+            'requester_name.max'        => 'O nome do solicitante não pode ter mais que 255 caracteres.',
+
+            'destination.required'      => 'O destino é obrigatório.',
+            'destination.string'        => 'O destino deve ser um texto.',
+            'destination.max'           => 'O destino não pode ter mais que 255 caracteres.',
+
+            'departure_date.required'   => 'A data de partida é obrigatória.',
+            'departure_date.date_format' => 'A data de partida deve ser uma data válida e estar no formato AAAA-MM-DD.',
+            'departure_date.after'      => 'A data de partida deve ser uma data futura.',
+
+            'return_date.required'      => 'A data de retorno é obrigatória.',
+            'return_date.date_format'   => 'A data de retorno deve ser uma data válida e estar no formato AAAA-MM-DD.',
+            'return_date.after'        => 'A data de retorno deve ser posterior à data de partida.',
+        ];
+    }
+}

--- a/backend/app/Http/Resources/TravelOrderResource.php
+++ b/backend/app/Http/Resources/TravelOrderResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TravelOrderResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'requester_name' => $this->requester_name,
+            'status' => $this->status,
+            'destination' => $this->destination,
+            'departure_date' => $this->departure_date,
+            'return_date' => $this->return_date,
+        ];
+    }
+}

--- a/backend/app/Models/TravelOrder.php
+++ b/backend/app/Models/TravelOrder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use App\Enum\TravelOrderStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TravelOrder extends Model
+{
+    protected $casts = [
+        'status' => TravelOrderStatus::class
+    ];
+    protected $fillable = [
+        'requester_name',
+        'destination',
+        'departure_date',
+        'return_date',
+        'user_id',
+        'status'
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use PHPOpenSourceSaver\JWTAuth\Contracts\JWTSubject;
@@ -59,5 +60,10 @@ class User extends Authenticatable implements JWTSubject
     public function getJWTCustomClaims()
     {
         return [];
+    }
+
+    public function travelOrders(): HasMany
+    {
+        return $this->hasMany(TravelOrder::class);
     }
 }

--- a/backend/app/Services/TravelOrderService.php
+++ b/backend/app/Services/TravelOrderService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services;
+
+use App\DTO\TravelOrderDTO;
+use App\Enum\TravelOrderStatus;
+use App\Http\Resources\TravelOrderResource;
+use App\Models\TravelOrder;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * An service that is responsible to deal with Travel Orders logic
+ */
+interface TravelOrderServiceInterface
+{
+  public function createOrder(User $user, TravelOrderDTO $order): TravelOrderResource;
+}
+class TravelOrderService implements TravelOrderServiceInterface
+{
+  public function createOrder(User $user, TravelOrderDTO $orderDTO): TravelOrderResource
+  {
+    if (!$user->id) {
+      abort(401, 'O usuário não possui permissão para fazer essa requisição');
+    }
+    try {
+      DB::beginTransaction();
+      $data = [
+        'user_id' => $user->id,
+        'requester_name' => $orderDTO->requester_name,
+        'destination' => $orderDTO->destination,
+        'departure_date' => $orderDTO->departure_date,
+        'return_date' => $orderDTO->return_date,
+        'status' => TravelOrderStatus::Pending
+      ];
+      $created_order = TravelOrder::create($data);
+      DB::commit();
+      return (new TravelOrderResource($created_order))
+        ->additional([
+          'message' => 'Pedido de viagem criado com sucesso'
+        ]);
+    } catch (QueryException $e) {
+      DB::rollBack();
+      abort(500, 'Ocorreu um erro ao salvar seu pedido. Por favor tente novamente mais tarde.' . $e->getMessage());
+    } catch (\Exception $e) {
+      DB::rollBack();
+      abort(500, 'Um erro inesperado ocorreu durante sua solicitação. Por favor tente novamente mais tarde.');
+    }
+  }
+}

--- a/backend/database/migrations/2025_06_28_164223_create_travel_orders_table.php
+++ b/backend/database/migrations/2025_06_28_164223_create_travel_orders_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Enum\TravelOrderStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('travel_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('requester_name')->max(255);
+            $table->string('status')->default(TravelOrderStatus::Pending->value);
+            $table->string('destination')->max(255);
+            $table->date('departure_date');
+            $table->date('return_date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('travel_orders');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\TravelOrderController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('auth')->group(function () {
@@ -12,3 +13,4 @@ Route::prefix('auth')->group(function () {
 
 
 Route::get('/me', [AuthController::class, 'me'])->name('me');
+Route::apiResource('travel-orders', TravelOrderController::class);

--- a/backend/tests/Feature/Auth/LoginUserTest.php
+++ b/backend/tests/Feature/Auth/LoginUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/backend/tests/Feature/Auth/LoginUserTest.php
+++ b/backend/tests/Feature/Auth/LoginUserTest.php
@@ -48,7 +48,7 @@ class LoginUserTest extends TestCase
         $email = $this->faker->safeEmail;
         $this->assertDatabaseCount('users', 0);
         $loginResponse = $this->postJson(route('login'), ['email' => $email, 'password' => $password]);
-        $loginResponse->assertStatus(401);
+        $loginResponse->assertUnauthorized();
     }
     /**
      * Test existent user with wrong password receive unauthorized status code
@@ -61,7 +61,7 @@ class LoginUserTest extends TestCase
         $successLoginResponse = $this->postJson(route('login'), ['email' => $user->email, 'password' => $password]);
         $successLoginResponse->assertSuccessful();
         $unauthorizedloginResponse = $this->postJson(route('login'), ['email' => $user->email, 'password' => $wrongPassword]);
-        $unauthorizedloginResponse->assertStatus(401);
+        $unauthorizedloginResponse->assertUnauthorized();
     }
     /**
      * Test logged user can use /api/user endpoint

--- a/backend/tests/Feature/Auth/LogoutUserTest.php
+++ b/backend/tests/Feature/Auth/LogoutUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/backend/tests/Feature/Auth/LogoutUserTest.php
+++ b/backend/tests/Feature/Auth/LogoutUserTest.php
@@ -76,7 +76,7 @@ class LogoutUserTest extends TestCase
         $logoutResponse = $this->postJson(uri: route('logout'), headers: ['Authorization' => "bearer $token"]);
         $logoutResponse->assertSuccessful();
         $newrequest = $this->getJson(uri: route('me'), headers: ['Authorization' => "bearer $token"]);
-        $newrequest->assertStatus(401);
+        $newrequest->assertUnauthorized();
     }
     /**
      * Testing unauthenticated user trying to logout
@@ -84,6 +84,6 @@ class LogoutUserTest extends TestCase
     public function test_unauthenticated_logout(): void
     {
         $logoutResponse = $this->postJson(uri: route('logout'));
-        $logoutResponse->assertStatus(401);
+        $logoutResponse->assertUnauthorized();
     }
 }

--- a/backend/tests/Feature/Auth/RefreshTokenTest.php
+++ b/backend/tests/Feature/Auth/RefreshTokenTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/backend/tests/Feature/Auth/RefreshTokenTest.php
+++ b/backend/tests/Feature/Auth/RefreshTokenTest.php
@@ -32,7 +32,7 @@ class RefreshTokenTest extends TestCase
     public function test_unauthorized_access_to_refresh_route(): void
     {
         $response = $this->post(route('refresh'));
-        $response->assertStatus(401);
+        $response->assertUnauthorized();
     }
     protected function get_user_token(): string
     {
@@ -97,7 +97,7 @@ class RefreshTokenTest extends TestCase
             uri: route('refresh'),
             headers: ['Authorization' => "Bearer {$token}"]
         );
-        $refreshResponse->assertStatus(401);
+        $refreshResponse->assertUnauthorized();
         Carbon::setTestNow(null); // reset time
     }
 }

--- a/backend/tests/Feature/Auth/RegisterUserTest.php
+++ b/backend/tests/Feature/Auth/RegisterUserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Auth;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
 

--- a/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
+++ b/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\TravelOrder;
 
+use App\Enum\TravelOrderStatus;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -46,6 +47,15 @@ class CreateTravelOrderTest extends TestCase
             ],
             'message'
         ]);
+    }
+    /**
+     * A created order should always start with status Pending
+     */
+    public function test_created_order_starts_with_pending_status(): void
+    {
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $this->well_formated_order_dto);
+        $response->assertSuccessful();
+        $this->assertEquals(TravelOrderStatus::Pending->value, $response['data']['status']);
     }
     /**
      * A request without a authorization token cannot be authorized

--- a/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
+++ b/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature\TravelOrder;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+use Tests\TestCase;
+
+class CreateTravelOrderTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+    protected array $well_formated_order_dto;
+    protected User $authenticatedUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->well_formated_order_dto =
+            [
+                'requester_name' => $this->faker->name,
+                'destination' => $this->faker->city,
+                'departure_date' => Carbon::tomorrow()->format('Y-m-d'),
+                'return_date' => Carbon::tomorrow()->addMonth(1)->format('Y-m-d')
+            ];
+        $this->authenticatedUser = User::factory()->create();
+    }
+    /**
+     * A request with authorized user and correct data should create order
+     */
+    public function test_correct_request_and_authorized_user_should_create_order()
+    {
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $this->well_formated_order_dto);
+        $response->assertSuccessful();
+        $response->assertExactJsonStructure([
+            'data' => [
+                'id',
+                'requester_name',
+                'status',
+                'destination',
+                'departure_date',
+                'return_date',
+            ],
+            'message'
+        ]);
+    }
+    /**
+     * A request without a authorization token cannot be authorized
+     */
+    public function test_unauthorized_user_cannot_create_order(): void
+    {
+        $response = $this->postJson(uri: route('travel-orders.store'), data: []);
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * A request with invalid requester_name should not be proceeded
+     */
+    public function test_order_with_invalid_requester_name_should_not_proceed(): void
+    {
+        $data = (array) $this->well_formated_order_dto;
+        $data['requester_name'] = '';
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "requester_name",
+            ],
+        );
+
+        $non_string_name_test = 1;
+        $data['requester_name'] = $non_string_name_test;
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "requester_name",
+            ],
+        );
+
+        $name_bigger_than_max_characters = Str::random(256);
+        $data['requester_name'] = $name_bigger_than_max_characters;
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "requester_name",
+            ],
+        );
+    }
+    /**
+     * A request with invalid destination should not be proceeded
+     */
+    public function test_order_with_invalid_destination_should_not_proceed(): void
+    {
+        $data = (array) $this->well_formated_order_dto;
+        $data['destination'] = '';
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "destination",
+            ],
+        );
+
+        $non_string_destination_test = 1;
+        $data['destination'] = $non_string_destination_test;
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "destination",
+            ],
+        );
+
+        $destination_bigger_than_max_characters = Str::random(256);
+        $data['destination'] = $destination_bigger_than_max_characters;
+        $response = $this->actingAs($this->authenticatedUser)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "destination",
+            ],
+        );
+    }
+    /**
+     * A request with invalid departure_date should not proceeded
+     */
+    public function test_order_with_invalid_departure_date_should_not_proceed(): void
+    {
+        $user = User::factory()->create();
+        $data = (array) $this->well_formated_order_dto;
+        $data['departure_date'] = null;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "departure_date",
+            ]
+        );
+
+        $data['departure_date'] = 33;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "departure_date",
+            ]
+        );
+
+        $past_departure_date_test = Carbon::yesterday()->format('Y-m-d');
+        $data['departure_date'] = $past_departure_date_test;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "departure_date",
+            ]
+        );
+    }
+    /**
+     * A request with invalid return_date should not proceeded
+     */
+    public function test_order_with_invalid_return_date_should_not_proceed(): void
+    {
+        $user = User::factory()->create();
+        $data = (array) $this->well_formated_order_dto;
+        $data['return_date'] = null;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "return_date",
+            ]
+        );
+
+        $data['return_date'] = 33;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "return_date",
+            ]
+        );
+
+        $before_departure_date_test = Carbon::createFromFormat('Y-m-d', $data['departure_date']);
+        $data['return_date'] = $before_departure_date_test;
+        $response = $this->actingAs($user)->postJson(uri: route('travel-orders.store'), data: $data);
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(
+            [
+                "return_date",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
# About this PR
Here i've added the functionality that is responsible to create an TravelOrder via the `/api/travel-orders` POST method
- [x] create tests for ensure that users can create orders accourdingly to #2 
- [x] create TravelOrder Resource to ensure structured data response
- [x] create Form Request for store TravelOrder to validate requests
- [x] create TravelOrder DTO to ensure an imutable TravelOrder Object is being transported between system layers
- [x] create  TravelOrderService to handle business logic
- [x] add `apiResource` of  `travel-orders` routes in `api`
