### PR TITLE
Feat/list travel orders

### DIFF
--- a/backend/app/Http/Resources/TravelOrderResource.php
+++ b/backend/app/Http/Resources/TravelOrderResource.php
@@ -21,6 +21,8 @@ class TravelOrderResource extends JsonResource
             'destination' => $this->destination,
             'departure_date' => $this->departure_date,
             'return_date' => $this->return_date,
+            'user_id' => $this->user_id,
+            'created_at' => $this->created_at
         ];
     }
 }

--- a/backend/app/Models/TravelOrder.php
+++ b/backend/app/Models/TravelOrder.php
@@ -3,11 +3,13 @@
 namespace App\Models;
 
 use App\Enum\TravelOrderStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TravelOrder extends Model
 {
+    use HasFactory;
     protected $casts = [
         'status' => TravelOrderStatus::class
     ];

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -65,8 +64,8 @@ class User extends Authenticatable implements JWTSubject
         return [];
     }
 
-    public function travelOrders(): BelongsTo
+    public function travelOrders(): HasMany
     {
-        return $this->belongsTo(TravelOrder::class);
+        return $this->hasMany(TravelOrder::class);
     }
 }

--- a/backend/app/Traits/AssertAllResourcesExistsWithKeyValue.php
+++ b/backend/app/Traits/AssertAllResourcesExistsWithKeyValue.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Traits;
+
+trait AssertAllResourcesExistsWithKeyValue
+{
+  /**
+   * This will assert that a every $resource has the $key with $value on it
+   * @param string $key What you are searching for
+   * @param $value The value that you are expect to find
+   * @param array $resources The array that contains your keys
+   */
+  public function assertAllResourcesExistsWithKeyValue(string $key, $value, array $resources, string $message = '')
+  {
+    $found = true;
+    foreach ($resources as $resource) {
+      if (array_key_exists($key, $resource) && $resource[$key] !== $value) {
+        $found = false;
+        break;
+      }
+    }
+    $this->assertTrue($found, $message);
+  }
+  /**
+   * Ensures that each resource does not contain the specified key with the given value
+   * @param string $key What you are searching for
+   * @param $value The value that you are expect to find
+   * @param array $resources The array that contains your keys
+   */
+  public function assertResourcesNotHaveKeyWithValue(string $key, $value, array $resources, string $message = '')
+  {
+    $found = true;
+    foreach ($resources as $resource) {
+      if (array_key_exists($key, $resource) && $resource[$key] === $value) {
+        $found = false;
+        break;
+      }
+    }
+    $this->assertTrue($found, $message);
+  }
+  public function assertResourceHaveKeyWithValue(string $key, $value, array $resources, string $message = '')
+  {
+    $found = false;
+    foreach ($resources as $resource) {
+      if (array_key_exists($key, $resource) && $resource[$key] === $value) {
+        $found = true;
+        break;
+      }
+    }
+    $this->assertTrue($found, $message);
+  }
+}

--- a/backend/database/factories/TravelOrderFactory.php
+++ b/backend/database/factories/TravelOrderFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TravelOrder>
+ */
+class TravelOrderFactory extends Factory
+{
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id'        => User::factory(),
+            'requester_name' => fake()->name(),
+            'destination'    => fake()->city(),
+            'departure_date' => fake()
+                ->dateTimeBetween('now', '+1 year')
+                ->format('Y-m-d'),
+            'return_date' => fake()->dateTimeBetween('+1 year', '+2 years')->format('Y-m-d')
+        ];
+    }
+}

--- a/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
+++ b/backend/tests/Feature/TravelOrder/CreateTravelOrderTest.php
@@ -44,6 +44,8 @@ class CreateTravelOrderTest extends TestCase
                 'destination',
                 'departure_date',
                 'return_date',
+                'user_id',
+                'created_at'
             ],
             'message'
         ]);

--- a/backend/tests/Feature/TravelOrder/ListTravelOrdersTest.php
+++ b/backend/tests/Feature/TravelOrder/ListTravelOrdersTest.php
@@ -143,9 +143,8 @@ class ListTravelOrdersTest extends TestCase
     }
     public function test_filter_travel_orders_by_status(): void
     {
-        // create orders with different statuses
-        $pendingOrder  = TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Pending->value]);
-        $approvedOrder = TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Approved->value]);
+        TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Pending->value]);
+        TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Approved->value]);
 
         $response = $this->actingAs($this->user)
             ->getJson(route('travel-orders.index', ['status' => TravelOrderStatus::Pending->value]));
@@ -153,7 +152,6 @@ class ListTravelOrdersTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure(['data' => [['id', 'status', 'destination', 'departure_date', 'return_date']]]);
 
-        // only pending orders are returned
         $this->assertAllResourcesExistsWithKeyValue(
             key: 'status',
             value: TravelOrderStatus::Pending->value,
@@ -168,8 +166,8 @@ class ListTravelOrdersTest extends TestCase
 
     public function test_filter_travel_orders_by_destination(): void
     {
-        $nyOrder = TravelOrder::factory()->for($this->user)->create(['destination' => 'New York']);
-        $laOrder = TravelOrder::factory()->for($this->user)->create(['destination' => 'Los Angeles']);
+        TravelOrder::factory()->for($this->user)->create(['destination' => 'New York']);
+        TravelOrder::factory()->for($this->user)->create(['destination' => 'Los Angeles']);
 
         $response = $this->actingAs($this->user)
             ->getJson(route('travel-orders.index', ['destination' => 'New York']));

--- a/backend/tests/Feature/TravelOrder/ListTravelOrdersTest.php
+++ b/backend/tests/Feature/TravelOrder/ListTravelOrdersTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Feature\TravelOrder;
+
+use App\Enum\TravelOrderStatus;
+use App\Models\TravelOrder;
+use App\Models\User;
+use App\Traits\AssertAllResourcesExistsWithKeyValue;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertNotNull;
+
+
+class ListTravelOrdersTest extends TestCase
+{
+    use WithFaker, RefreshDatabase, AssertAllResourcesExistsWithKeyValue;
+    protected User $user;
+    protected string $existingOrderId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $orders = TravelOrder::factory()
+            ->count(3)
+            ->for($this->user)
+            ->create();
+        $this->existingOrderId = $orders[0]->id;
+    }
+    /**
+     * A travel order should be returned by its own user creator.
+     */
+    public function test_travel_order_should_be_returned_to_owner(): void
+    {
+        assertNotNull($this->existingOrderId);
+        assertEquals(TravelOrder::find($this->existingOrderId)->id, $this->existingOrderId);
+        $response = $this->actingAs($this->user)->get(route('travel-orders.index'));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    "requester_name",
+                    "status",
+                    "destination",
+                    "departure_date",
+                    "return_date",
+                ]
+            ]
+        ]);
+    }
+    /**
+     * A common user cannot see travel orders from other users.
+     */
+    public function test_common_user_cannot_see_travel_orders_from_others(): void
+    {
+        assertNotNull($this->existingOrderId);
+        assertEquals(TravelOrder::find($this->existingOrderId)->id, $this->existingOrderId);
+        $other_user = User::factory()
+            ->has(TravelOrder::factory()->count(3))
+            ->create();
+        $response_other = $this->actingAs($other_user)->get(route('travel-orders.index'));
+        $response_current = $this->actingAs($this->user)->get(route('travel-orders.index'));
+        $response_other->assertSuccessful();
+        $response_current->assertSuccessful();
+        $this->assertNotEqualsCanonicalizing($response_other['data'], $response_current['data']);
+        $this->assertAllResourcesExistsWithKeyValue(
+            key: 'user_id',
+            value: $other_user->id,
+            resources: $response_other['data']
+        );
+        $this->assertAllResourcesExistsWithKeyValue(
+            key: 'user_id',
+            value: $this->user->id,
+            resources: $response_current['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'user_id',
+            value: $this->user->id,
+            resources: $response_other['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'user_id',
+            value: $other_user->id,
+            resources: $response_current['data']
+        );
+    }
+    /**
+     * A administrator should be able to see all orders on the system.
+     */
+    public function test_travel_orders_should_be_returned_to_other_admin_user(): void
+    {
+        assertNotNull($this->existingOrderId);
+        assertEquals(TravelOrder::find($this->existingOrderId)->id, $this->existingOrderId);
+        $other_user = User::factory()
+            ->isAdmin()
+            ->has(
+                TravelOrder::factory()->count(3)
+            )
+            ->create();
+        $response_other = $this->actingAs($other_user)->get(route('travel-orders.index'));
+        $response_current = $this->actingAs($this->user)->get(route('travel-orders.index'));
+        $response_other->assertSuccessful();
+        $response_current->assertSuccessful();
+        $this->assertNotEqualsCanonicalizing($response_other['data'], $response_current['data']);
+
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'user_id',
+            value: $other_user->id,
+            resources: $response_current['data']
+        );
+
+        $this->assertResourceHaveKeyWithValue(
+            key: 'user_id',
+            value: $other_user->id,
+            resources: $response_other['data']
+        );
+        $this->assertResourceHaveKeyWithValue(
+            key: 'user_id',
+            value: $this->user->id,
+            resources: $response_other['data']
+        );
+        $this->assertAllResourcesExistsWithKeyValue(
+            key: 'user_id',
+            value: $this->user->id,
+            resources: $response_current['data']
+        );
+    }
+    /**
+     * A unauthenticated user cannot see any travelOrder
+     */
+    public function test_travel_orders_should_not_be_returned_to_unauthenticated_users(): void
+    {
+        assertNotNull($this->existingOrderId);
+        assertEquals(TravelOrder::find($this->existingOrderId)->id, $this->existingOrderId);
+        $response = $this->getJson(route('travel-orders.index'));
+        $response->assertUnauthorized();
+        $response->assertJsonStructure([
+            'message'
+        ]);
+    }
+    public function test_filter_travel_orders_by_status(): void
+    {
+        // create orders with different statuses
+        $pendingOrder  = TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Pending->value]);
+        $approvedOrder = TravelOrder::factory()->for($this->user)->create(['status' => TravelOrderStatus::Approved->value]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson(route('travel-orders.index', ['status' => TravelOrderStatus::Pending->value]));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['data' => [['id', 'status', 'destination', 'departure_date', 'return_date']]]);
+
+        // only pending orders are returned
+        $this->assertAllResourcesExistsWithKeyValue(
+            key: 'status',
+            value: TravelOrderStatus::Pending->value,
+            resources: $response['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'status',
+            value: TravelOrderStatus::Approved->value,
+            resources: $response['data']
+        );
+    }
+
+    public function test_filter_travel_orders_by_destination(): void
+    {
+        $nyOrder = TravelOrder::factory()->for($this->user)->create(['destination' => 'New York']);
+        $laOrder = TravelOrder::factory()->for($this->user)->create(['destination' => 'Los Angeles']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson(route('travel-orders.index', ['destination' => 'New York']));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['data' => [['id', 'status', 'destination', 'departure_date', 'return_date']]]);
+
+        $this->assertAllResourcesExistsWithKeyValue(
+            key: 'destination',
+            value: 'New York',
+            resources: $response['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'destination',
+            value: 'Los Angeles',
+            resources: $response['data']
+        );
+    }
+
+    public function test_filter_travel_orders_by_start_and_end_date(): void
+    {
+        $newUser = User::factory()
+            ->create();
+        $orderBefore  = TravelOrder::factory()->for($newUser)->create(['departure_date' => '2021-01-01', 'return_date' => '2022-01-01']);
+        $orderInRange = TravelOrder::factory()->for($newUser)->create(['departure_date' => '2022-01-01', 'return_date' => '2023-01-01']);
+        $orderAfter   = TravelOrder::factory()->for($newUser)->create(['departure_date' => '2023-01-01', 'return_date' => '2024-01-01']);
+        $response = $this->actingAs($newUser)
+            ->getJson(uri: route('travel-orders.index', [
+                'start_date' => $orderInRange->departure_date,
+                'end_date'   => $orderInRange->return_date,
+            ]));
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    [
+                        'id',
+                        'status',
+                        'destination',
+                        'departure_date',
+                        'return_date'
+                    ]
+                ]
+            ]);
+        $this->assertResourceHaveKeyWithValue(
+            key: 'departure_date',
+            value: $orderInRange->departure_date,
+            resources: $response['data']
+        );
+        $this->assertResourceHaveKeyWithValue(
+            key: 'return_date',
+            value: $orderInRange->return_date,
+            resources: $response['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'departure_date',
+            value: $orderBefore->departure_date,
+            resources: $response['data']
+        );
+        $this->assertResourcesNotHaveKeyWithValue(
+            key: 'departure_date',
+            value: $orderAfter->departure_date,
+            resources: $response['data']
+        );
+    }
+}

--- a/backend/tests/Feature/TravelOrder/ShowTravelOrderTest.php
+++ b/backend/tests/Feature/TravelOrder/ShowTravelOrderTest.php
@@ -48,7 +48,9 @@ class ShowTravelOrderTest extends TestCase
                 "status",
                 "destination",
                 "departure_date",
-                "return_date"
+                "return_date",
+                "user_id",
+                "created_at",
             ]
         ]);
     }
@@ -84,6 +86,8 @@ class ShowTravelOrderTest extends TestCase
                 "destination",
                 "departure_date",
                 "return_date",
+                "user_id",
+                "created_at",
                 "user" => [
                     'name',
                     'email'


### PR DESCRIPTION
# About this PR

- [x] now users can list all their travel orders using filters like status, start_date, end_date and destination
- [x] now users will see user_id and created_at column in travel order resource
- [x] add tests to ensure list logic correctness