### PR TITLE
Feat/update travel order

### DIFF
--- a/backend/app/DTO/TravelOrderDTO.php
+++ b/backend/app/DTO/TravelOrderDTO.php
@@ -29,7 +29,7 @@ readonly class TravelOrderDTO
       destination: $data['destination'],
       departure_date: Carbon::parse($data['departure_date']),
       return_date: Carbon::parse($data['return_date']),
-      price: $data['price'],
+      price: $data['price'] ?? "0.0",
       hosting: array_key_exists('hosting', $data) ? $data['hosting'] : "",
       transportation: array_key_exists('transportation', $data) ? $data['transportation'] : "",
       description: array_key_exists('description', $data) ? $data['description'] : "",

--- a/backend/app/Http/Controllers/TravelOrderController.php
+++ b/backend/app/Http/Controllers/TravelOrderController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\DTO\TravelOrderDTO;
 use App\Enum\TravelOrderStatus;
 use App\Http\Requests\StoreTravelOrderRequest;
+use App\Http\Requests\UpdateTravelOrderRequest;
 use App\Models\TravelOrder;
 use App\Services\TravelOrderService;
 use Illuminate\Http\Request;
@@ -105,9 +106,11 @@ class TravelOrderController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, TravelOrder $travel_order)
+    public function update(UpdateTravelOrderRequest $request, TravelOrder $travel_order)
     {
-        //
+        Gate::authorize('update', $travel_order);
+        $new_order = $request->validated();
+        return $this->service->updateOrder($new_order, $travel_order);
     }
 
     /**

--- a/backend/app/Services/TravelOrderService.php
+++ b/backend/app/Services/TravelOrderService.php
@@ -58,6 +58,15 @@ interface TravelOrderServiceInterface
   public function approveOrder(
     TravelOrder $order
   ): TravelOrderResource;
+  /**
+   * Update the current travel order 
+   * @param array $data the order data to be updated
+   * @param TravelOrder $order the order that is going to be updated
+   */
+  public function updateOrder(
+    array $data,
+    TravelOrder $order,
+  ): TravelOrderResource;
 }
 class TravelOrderService implements TravelOrderServiceInterface
 {
@@ -146,6 +155,18 @@ class TravelOrderService implements TravelOrderServiceInterface
     } catch (\Error $e) {
       DB::rollBack();
       abort(500, 'Um erro inesperado ocorreu ao tentar aprovar este pedido. Por favor tente novamente mais tarde.');
+    }
+  }
+  public function updateOrder(array $data, TravelOrder $order): TravelOrderResource
+  {
+    try {
+      DB::beginTransaction();
+      $order->update($data);
+      DB::commit();
+      return $order->fresh()->toResource()->additional(['message' => 'Pedido atualizado com sucesso.']);
+    } catch (\Throwable $th) {
+      DB::rollBack();
+      abort(500, 'Um erro inesperado ocorreu ao tentar atualizar este pedido. Por favor tente novamente mais tarde.');
     }
   }
 }

--- a/backend/tests/Feature/TravelOrder/UpdateTravelOrderTest.php
+++ b/backend/tests/Feature/TravelOrder/UpdateTravelOrderTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\TravelOrder;
+
+use App\Enum\TravelOrderStatus;
+use App\Models\TravelOrder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UpdateTravelOrderTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+    /**
+     * A common user cannot update orders from others users
+     */
+    public function test_common_user_cannot_update_order_from_others(): void
+    {
+        $user = User::factory()->create();
+        $order = TravelOrder::factory()->for(User::factory())->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+
+        $response->assertForbidden();
+    }
+    /**
+     * A common user cannot update approved orders
+     */
+    public function test_common_user_cannot_update_approved_orders(): void
+    {
+        $user = User::factory()->create();
+        $order = TravelOrder::factory([
+            "status" => TravelOrderStatus::Approved
+        ])->for($user)
+            ->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertForbidden();
+    }
+    /**
+     * A common user cannot update cancelled orders
+     */
+    public function test_common_user_cannot_update_cancelled_orders(): void
+    {
+        $user = User::factory()->create();
+        $order = TravelOrder::factory([
+            "status" => TravelOrderStatus::Cancelled
+        ])->for($user)
+            ->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertForbidden();
+    }
+    /**
+     * A common user can update order their own orders
+     */
+    public function test_common_user_can_update_own_orders(): void
+    {
+        $user = User::factory()->create();
+        $order = TravelOrder::factory(['status' => TravelOrderStatus::Pending])->for($user)->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertSuccessful();
+    }
+    /**
+     * A administrator cannot update cancelled orders
+     */
+    public function test_administrators_cannot_update_cancelled_orders(): void
+    {
+        $user = User::factory()->isAdmin()->create();
+        $order = TravelOrder::factory([
+            "status" => TravelOrderStatus::Cancelled
+        ])->for($user)
+            ->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertForbidden();
+    }
+    /**
+     * A administrator cannot update approved orders
+     */
+    public function test_administrators_cannot_update_approved_orders(): void
+    {
+        $user = User::factory()->isAdmin()->create();
+        $order = TravelOrder::factory([
+            "status" => TravelOrderStatus::Approved
+        ])->for($user)
+            ->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertForbidden();
+    }
+    /**
+     * A administrator can update order from others
+     */
+    public function test_administrators_can_update_order_from_others(): void
+    {
+        $user = User::factory()->isAdmin()->create();
+        $order = TravelOrder::factory()->for(User::factory())->create();
+        $response = $this->actingAs($user)->putJson(route('travel-orders.update', $order));
+        $response->assertSuccessful();
+    }
+}


### PR DESCRIPTION
#
This pull request introduces functionality to update travel orders, including validation, service logic, and comprehensive tests. The changes ensure proper authorization and error handling, while also adding default values in the DTO for improved robustness.

### New functionality for updating travel orders:

* **Controller updates**: The `update` method in `TravelOrderController` now uses `UpdateTravelOrderRequest` for validation, includes authorization checks via `Gate`, and delegates the update logic to the service layer. (`backend/app/Http/Controllers/TravelOrderController.php`)
* **Service layer enhancements**: Added the `updateOrder` method in `TravelOrderService`, which handles database transactions, updates the travel order, and provides appropriate error handling. (`backend/app/Services/TravelOrderService.php`)

### Validation and default handling improvements:

* **DTO adjustments**: Modified `TravelOrderDTO` to set a default value of `"0.0"` for the `price` field if it is not provided. (`backend/app/DTO/TravelOrderDTO.php`)

### Comprehensive testing for update functionality:

* **Feature tests**: Added `UpdateTravelOrderTest` to cover various scenarios, including authorization checks for common users and administrators, and ensuring proper behavior for different order statuses. (`backend/tests/Feature/TravelOrder/UpdateTravelOrderTest.php`)

### Minor additions:

* **Request import**: Added `UpdateTravelOrderRequest` to the imports in `TravelOrderController`. (`backend/app/Http/Controllers/TravelOrderController.php`)
* **Service interface update**: Declared the `updateOrder` method in the `TravelOrderServiceInterface`. (`backend/app/Services/TravelOrderService.php`)